### PR TITLE
contracts-v2 enabled VM integration updates

### DIFF
--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -152,67 +152,65 @@ export default class EVM {
         ? this._vm.getContractByName('mockOVM_ECDSAContractAccount')
         : this._vm.getContract(message.to)
 
-      if (isECDSAContractAccount) { console.log(`account code is: ${toHexString(code)}`) }
+      // if (target) {
+      //   let methodId = '0x' + message.data.slice(0, 4).toString('hex')
 
-      if (target) {
-        let methodId = '0x' + message.data.slice(0, 4).toString('hex')
+      //   let fragment = target.iface.getFunction(methodId)
 
-        let fragment = target.iface.getFunction(methodId)
+      //   // try {
+      //   //   fragment = target.iface.getFunction(methodId)
+      //   // } catch (err) {
+      //   //   console.error(
+      //   //     `\nCaught decoding error for ${target.name} with data: ${toHexString(
+      //   //       message.data,
+      //   //     )}, ${err}`,
+      //   //   )
+      //   //   console.error(
+      //   //     `Attempting to try again with function parameters removed in sighash calculation.`,
+      //   //   )
 
-        // try {
-        //   fragment = target.iface.getFunction(methodId)
-        // } catch (err) {
-        //   console.error(
-        //     `\nCaught decoding error for ${target.name} with data: ${toHexString(
-        //       message.data,
-        //     )}, ${err}`,
-        //   )
-        //   console.error(
-        //     `Attempting to try again with function parameters removed in sighash calculation.`,
-        //   )
+      //   //   let correctedMethodId: string | undefined
+      //   //   for (const functionName of Object.keys(target.iface.functions)) {
+      //   //     const possibleMethodId = ethers.utils.id(functionName.split('(')[0] + '()').slice(0, 10)
+      //   //     if (possibleMethodId === methodId) {
+      //   //       correctedMethodId = ethers.utils.id(functionName).slice(0, 10)
+      //   //       break
+      //   //     }
+      //   //   }
 
-        //   let correctedMethodId: string | undefined
-        //   for (const functionName of Object.keys(target.iface.functions)) {
-        //     const possibleMethodId = ethers.utils.id(functionName.split('(')[0] + '()').slice(0, 10)
-        //     if (possibleMethodId === methodId) {
-        //       correctedMethodId = ethers.utils.id(functionName).slice(0, 10)
-        //       break
-        //     }
-        //   }
+      //   //   if (!correctedMethodId) {
+      //   //     console.error(`Cannot find a suitable function match, throwing.`)
+      //   //     throw err
+      //   //   }
 
-        //   if (!correctedMethodId) {
-        //     console.error(`Cannot find a suitable function match, throwing.`)
-        //     throw err
-        //   }
+      //   //   try {
+      //   //     fragment = target.iface.getFunction(correctedMethodId)
+      //   //     methodId = correctedMethodId
+      //   //     console.log(
+      //   //       `Found a suitable function match: ${target.name}.${fragment.name}, continuing.`,
+      //   //     )
+      //   //   } catch (err) {
+      //   //     console.error(
+      //   //       `Second decoding attempt failed for ${target.name} with data: ${toHexString(
+      //   //         message.data,
+      //   //       )}, ${err}`,
+      //   //     )
+      //   //     throw err
+      //   //   }
+      //   // }
 
-        //   try {
-        //     fragment = target.iface.getFunction(correctedMethodId)
-        //     methodId = correctedMethodId
-        //     console.log(
-        //       `Found a suitable function match: ${target.name}.${fragment.name}, continuing.`,
-        //     )
-        //   } catch (err) {
-        //     console.error(
-        //       `Second decoding attempt failed for ${target.name} with data: ${toHexString(
-        //         message.data,
-        //       )}, ${err}`,
-        //     )
-        //     throw err
-        //   }
-        // }
+      //   // message.data = Buffer.concat([fromHexString(methodId), message.data.slice(4)])
+      //   const functionArgs = target.iface.decodeFunctionData(fragment, toHexString(message.data))
 
-        // message.data = Buffer.concat([fromHexString(methodId), message.data.slice(4)])
-        const functionArgs = target.iface.decodeFunctionData(fragment, toHexString(message.data))
-
-        console.log(`\nCalling ${target.name}.${fragment.name} with args: ${functionArgs}`)
-        console.log(`as raw data this is: ${toHexString(message.data)}`)
-      } else {
-        console.log(
-          `Calling unknown contract (${toHexString(message.to)}) with data: ${toHexString(
-            message.data,
-          )}`,
-        )
-      }
+      //   console.log(`\nCalling ${target.name}.${fragment.name} with args: ${functionArgs}`)
+      //   console.log(`as raw data this is: ${toHexString(message.data)}`)
+      // } else {
+      //   console.log(
+      //     `Calling unknown contract (${toHexString(message.to)}) with data: ${toHexString(
+      //       message.data,
+      //     )}`,
+      //   )
+      // }
 
       if (target && target.name === 'OVM_StateManager') {
         result = {
@@ -228,8 +226,6 @@ export default class EVM {
     } else {
       result = await this._executeCreate(message)
     }
-
-    console.log(`call result was: ${JSON.stringify(result.execResult.returnValue)}`)
 
     // TODO: Move `gasRefund` to a tx-level result object
     // instead of `ExecResult`.

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -505,7 +505,7 @@ export default class EVM {
   async _generateAddress(message: Message): Promise<Buffer> {
     return fromHexString(
       toHexAddress(
-        await this._vm.pStateManager.getContractStorage(
+        await this._state.getContractStorage(
           this._vm.contracts.OVM_ExecutionManager.address,
           Buffer.from('00'.repeat(31) + '0f', 'hex'),
         ),

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -220,7 +220,7 @@ export default class EVM {
           },
         }
       } else {
-        // todo: break out error cases and surface here
+        // todo: detect OVM-specific error cases and surface here
         result.execResult.exceptionError = new VmError(ERROR.OVM_ERROR)
       }
     }

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -155,52 +155,54 @@ export default class EVM {
       if (target) {
         let methodId = '0x' + message.data.slice(0, 4).toString('hex')
 
-        let fragment: any
-        try {
-          fragment = target.iface.getFunction(methodId)
-        } catch (err) {
-          console.error(
-            `\nCaught decoding error for ${target.name} with data: ${toHexString(
-              message.data,
-            )}, ${err}`,
-          )
-          console.error(
-            `Attempting to try again with function parameters removed in sighash calculation.`,
-          )
+        let fragment = target.iface.getFunction(methodId)
 
-          let correctedMethodId: string | undefined
-          for (const functionName of Object.keys(target.iface.functions)) {
-            const possibleMethodId = ethers.utils.id(functionName.split('(')[0] + '()').slice(0, 10)
-            if (possibleMethodId === methodId) {
-              correctedMethodId = ethers.utils.id(functionName).slice(0, 10)
-              break
-            }
-          }
+        // try {
+        //   fragment = target.iface.getFunction(methodId)
+        // } catch (err) {
+        //   console.error(
+        //     `\nCaught decoding error for ${target.name} with data: ${toHexString(
+        //       message.data,
+        //     )}, ${err}`,
+        //   )
+        //   console.error(
+        //     `Attempting to try again with function parameters removed in sighash calculation.`,
+        //   )
 
-          if (!correctedMethodId) {
-            console.error(`Cannot find a suitable function match, throwing.`)
-            throw err
-          }
+        //   let correctedMethodId: string | undefined
+        //   for (const functionName of Object.keys(target.iface.functions)) {
+        //     const possibleMethodId = ethers.utils.id(functionName.split('(')[0] + '()').slice(0, 10)
+        //     if (possibleMethodId === methodId) {
+        //       correctedMethodId = ethers.utils.id(functionName).slice(0, 10)
+        //       break
+        //     }
+        //   }
 
-          try {
-            fragment = target.iface.getFunction(correctedMethodId)
-            methodId = correctedMethodId
-            console.log(
-              `Found a suitable function match: ${target.name}.${fragment.name}, continuing.`,
-            )
-          } catch (err) {
-            console.error(
-              `Second decoding attempt failed for ${target.name} with data: ${toHexString(
-                message.data,
-              )}, ${err}`,
-            )
-            throw err
-          }
-        }
+        //   if (!correctedMethodId) {
+        //     console.error(`Cannot find a suitable function match, throwing.`)
+        //     throw err
+        //   }
+
+        //   try {
+        //     fragment = target.iface.getFunction(correctedMethodId)
+        //     methodId = correctedMethodId
+        //     console.log(
+        //       `Found a suitable function match: ${target.name}.${fragment.name}, continuing.`,
+        //     )
+        //   } catch (err) {
+        //     console.error(
+        //       `Second decoding attempt failed for ${target.name} with data: ${toHexString(
+        //         message.data,
+        //       )}, ${err}`,
+        //     )
+        //     throw err
+        //   }
+        // }
 
         message.data = Buffer.concat([fromHexString(methodId), message.data.slice(4)])
-
+        console.log(`BEGIN: POTAYTOES, data is: ${toHexString(message.data)}, target is: ${toHexAddress(message.to)}`)
         const functionArgs = target.iface.decodeFunctionData(fragment, toHexString(message.data))
+        console.log('END: POTAYTOES')
 
         console.log(`\nCalling ${target.name}.${fragment.name} with args: ${functionArgs}`)
       } else {

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -153,66 +153,6 @@ export default class EVM {
         ? this._vm.getContractByName('mockOVM_ECDSAContractAccount')
         : this._vm.getContract(message.to)
 
-      // if (target) {
-      //   let methodId = '0x' + message.data.slice(0, 4).toString('hex')
-
-      //   let fragment = target.iface.getFunction(methodId)
-
-      //   // try {
-      //   //   fragment = target.iface.getFunction(methodId)
-      //   // } catch (err) {
-      //   //   console.error(
-      //   //     `\nCaught decoding error for ${target.name} with data: ${toHexString(
-      //   //       message.data,
-      //   //     )}, ${err}`,
-      //   //   )
-      //   //   console.error(
-      //   //     `Attempting to try again with function parameters removed in sighash calculation.`,
-      //   //   )
-
-      //   //   let correctedMethodId: string | undefined
-      //   //   for (const functionName of Object.keys(target.iface.functions)) {
-      //   //     const possibleMethodId = ethers.utils.id(functionName.split('(')[0] + '()').slice(0, 10)
-      //   //     if (possibleMethodId === methodId) {
-      //   //       correctedMethodId = ethers.utils.id(functionName).slice(0, 10)
-      //   //       break
-      //   //     }
-      //   //   }
-
-      //   //   if (!correctedMethodId) {
-      //   //     console.error(`Cannot find a suitable function match, throwing.`)
-      //   //     throw err
-      //   //   }
-
-      //   //   try {
-      //   //     fragment = target.iface.getFunction(correctedMethodId)
-      //   //     methodId = correctedMethodId
-      //   //     console.log(
-      //   //       `Found a suitable function match: ${target.name}.${fragment.name}, continuing.`,
-      //   //     )
-      //   //   } catch (err) {
-      //   //     console.error(
-      //   //       `Second decoding attempt failed for ${target.name} with data: ${toHexString(
-      //   //         message.data,
-      //   //       )}, ${err}`,
-      //   //     )
-      //   //     throw err
-      //   //   }
-      //   // }
-
-      //   // message.data = Buffer.concat([fromHexString(methodId), message.data.slice(4)])
-      //   const functionArgs = target.iface.decodeFunctionData(fragment, toHexString(message.data))
-
-      //   console.log(`\nCalling ${target.name}.${fragment.name} with args: ${functionArgs}`)
-      //   console.log(`as raw data this is: ${toHexString(message.data)}`)
-      // } else {
-      //   console.log(
-      //     `Calling unknown contract (${toHexString(message.to)}) with data: ${toHexString(
-      //       message.data,
-      //     )}`,
-      //   )
-      // }
-
       if (target && target.name === 'OVM_StateManager') {
         result = {
           gasUsed: new BN(0),

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -184,10 +184,6 @@ export default class EVM {
       this._targetMessageResult = result
     }
 
-    // if (message.depth === 1 && (await this._state.getContractCode(message.to)).toString('hex') == this._vm.contracts.OVM_ECDSAContractAccount.code.toString('hex')) {
-    //   console.log(`found and set EOA acct message`)
-    //   this._entryPointResult = result
-    // }
     let wasDeployException = false
     if (message.depth === 0) {
       if (this._targetMessageResult) {

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -280,7 +280,7 @@ export default class Interpreter {
       const memSizeLogger = new Logger(callLogger.namespace + ':memorysize')
       const gasLogger = new Logger(callLogger.namespace + ':steps')
 
-      callLogger.open(`${description} ${contractName} at depth ${step.depth}`)
+      stepLogger.open(`${description} ${contractName} at depth ${step.depth}`)
 
       this._loggers[step.depth] = {
         callLogger,
@@ -305,17 +305,14 @@ export default class Interpreter {
       const length = stack[1].toNumber()
       const data = Buffer.from(memory.slice(offset, offset + length))
 
+      loggers.stepLogger.close()
       loggers.callLogger.log(`${op} with data: ${toHexString(data)}`)
-      loggers.callLogger.close()
       delete this._loggers[step.depth]
     } else if (op === 'CALL') {
       const target = stack[1].toBuffer()
       const offset = stack[3].toNumber()
       const length = stack[4].toNumber()
-
       const calldata = Buffer.from(memory.slice(offset, offset + length))
-
-
 
       const code = await this._state.getContractCode(target)
       const isECDSAContractAccount =
@@ -373,7 +370,7 @@ export default class Interpreter {
           .map((el, idx) => {
             return ` ${idx}: ${toHexString(el)}`
           })
-          .join('')}]\n`,
+          .join('')}]`,
       )
 
       if (

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -272,9 +272,9 @@ export default class Interpreter {
       const contractName = this._vm.getContract(step.address)
       const description = step.depth === 0 ? 'OVM TX starts with' : 'EVM STEPS for'
 
-      const addressStart = step.address.slice(0, 2).toString('hex')
-      const addressEnd = step.address.slice(step.address.length - 4).toString('hex')
-      const callLogger = new Logger(logger.namespace + ':0x' + addressStart + '..' + addressEnd + ':calls')
+      const addressStart = step.address.slice(0, 3).toString('hex')
+      const addressEnd = step.address.slice(step.address.length - 3).toString('hex')
+      const callLogger = new Logger(logger.namespace + ':0x' + addressStart + '..' + addressEnd + ':d' + step.depth + ':calls')
       const stepLogger = new Logger(callLogger.namespace + ':steps')
       const memLogger = new Logger(callLogger.namespace + ':memory')
       const memSizeLogger = new Logger(callLogger.namespace + ':memorysize')

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -357,29 +357,6 @@ export default class Interpreter {
           )}`,
         )
       }
-
-
-
-
-      // if (target.equals(this._vm.contracts.OVM_ExecutionManager.address)) {
-      //   const sighash = toHexString(calldata.slice(0, 4))
-      //   const fragment = this._vm.contracts.OVM_ExecutionManager.iface.getFunction(sighash)
-      //   const functionName = fragment.name
-      //   const functionArgs = this._vm.contracts.OVM_ExecutionManager.iface.decodeFunctionData(
-      //     fragment,
-      //     toHexString(calldata),
-      //   ) as any[]
-
-      //   loggers.callLogger.log(
-      //     `CALL to OVM_ExecutionManager.${functionName}\nDecoded calldata: ${functionArgs}\nEncoded calldata: ${toHexString(
-      //       calldata.slice(4),
-      //     )}`,
-      //   )
-      // } else {
-      //   loggers.callLogger.log(
-      //     `CALL to ${toHexAddress(target)} with data:\n${toHexString(calldata)}`,
-      //   )
-      // }
     } else {
       loggers.stepLogger.log(
         `opcode: ${op.padEnd(10, ' ')}  pc: ${step.pc.toString().padEnd(10, ' ')} gasLeft: ${step.gasLeft.toString()}\nstack: [${stack

--- a/lib/evm/message.ts
+++ b/lib/evm/message.ts
@@ -64,9 +64,9 @@ export default class Message {
     const calldata = vm.contracts.OVM_ExecutionManager.iface.encodeFunctionData('run', [
       {
         timestamp: new BN(block.header.timestamp).toNumber(),
-        number: new BN(block.header.number).toNumber(),
+        blockNumber: new BN(block.header.number).toNumber(),
         l1QueueOrigin: 0,
-        l1Txorigin: toHexString(this.caller),
+        l1TxOrigin: toHexString(this.caller),
         entrypoint: toHexString(this.caller),
         gasLimit: toHexString(notTooBigGasLimit.toBuffer()),
         data: vm.contracts.mockOVM_ECDSAContractAccount.iface.encodeFunctionData('execute', [

--- a/lib/evm/message.ts
+++ b/lib/evm/message.ts
@@ -59,6 +59,13 @@ export default class Message {
       throw new Error('Cannot create a message because the ExecutionManager does not exist.')
     }
 
+    console.log(`gaslimit is ${this.gasLimit.toString('hex')}`)
+    console.log(`ovm gaslimit is ${vm.emGasLimit}`)
+
+    const notTooBigGasLimit = BN.min(this.gasLimit, new BN(vm.emGasLimit))
+
+    console.log(`using gasLimit ${toHexString(notTooBigGasLimit.toBuffer())}`)
+
     const calldata = vm.contracts.OVM_ExecutionManager.iface.encodeFunctionData('run', [
       {
         timestamp: new BN(block.header.timestamp).toNumber(),
@@ -66,7 +73,7 @@ export default class Message {
         l1QueueOrigin: 0,
         l1Txorigin: toHexString(this.caller),
         entrypoint: toHexString(this.caller),
-        gasLimit: this.gasLimit.toNumber(),
+        gasLimit: toHexString(notTooBigGasLimit.toBuffer()),
         data: vm.contracts.mockOVM_ECDSAContractAccount.iface.encodeFunctionData('execute', [
           toHexString(this.data),
           0,

--- a/lib/evm/message.ts
+++ b/lib/evm/message.ts
@@ -59,12 +59,7 @@ export default class Message {
       throw new Error('Cannot create a message because the ExecutionManager does not exist.')
     }
 
-    console.log(`gaslimit is ${this.gasLimit.toString('hex')}`)
-    console.log(`ovm gaslimit is ${vm.emGasLimit}`)
-
     const notTooBigGasLimit = BN.min(this.gasLimit, new BN(vm.emGasLimit))
-
-    console.log(`using gasLimit ${toHexString(notTooBigGasLimit.toBuffer())}`)
 
     const calldata = vm.contracts.OVM_ExecutionManager.iface.encodeFunctionData('run', [
       {

--- a/lib/ovm/ovm-state-manager.ts
+++ b/lib/ovm/ovm-state-manager.ts
@@ -39,7 +39,7 @@ export class OvmStateManager {
     }
   }
 
-  async handleCall(message: Message): Promise<any> {
+  async handleCall(message: Message, context: any): Promise<any> {
     const methodId = '0x' + message.data.slice(0, 4).toString('hex')
     const fragment = this._iface.getFunction(methodId)
     const functionArgs = this._iface.decodeFunctionData(fragment, toHexString(message.data))
@@ -48,6 +48,10 @@ export class OvmStateManager {
     if (fragment.name in this._handlers) {
       ret = await this._handlers[fragment.name](...functionArgs)
       ret = ret === null || ret === undefined ? ret : [ret]
+    }
+
+    if (fragment.name == 'owner') {
+      ret = ['0x' + context.origin.toString('hex')]
     }
 
     try {

--- a/lib/ovm/ovm-state-manager.ts
+++ b/lib/ovm/ovm-state-manager.ts
@@ -55,7 +55,6 @@ export class OvmStateManager {
     }
 
     try {
-      console.log(`  ← Responding with: ${ret}`)
       const encodedRet = this._iface.encodeFunctionResult(fragment, ret)
       return fromHexString(encodedRet)
     } catch (err) {

--- a/lib/ovm/utils/buffer-utils.ts
+++ b/lib/ovm/utils/buffer-utils.ts
@@ -1,6 +1,8 @@
 export const toHexAddress = (buf: any): string => {
+  // pad shorter values out
   if (buf.length < 20) {
-    throw new Error('Buffer must be at least 20 bytes to be an address.')
+    buf = Buffer.concat([Buffer.alloc(31), buf])
+    // throw new Error('Buffer must be at least 20 bytes to be an address.')
   }
 
   return (

--- a/lib/ovm/utils/buffer-utils.ts
+++ b/lib/ovm/utils/buffer-utils.ts
@@ -2,7 +2,6 @@ export const toHexAddress = (buf: any): string => {
   // pad shorter values out
   if (buf.length < 20) {
     buf = Buffer.concat([Buffer.alloc(31), buf])
-    // throw new Error('Buffer must be at least 20 bytes to be an address.')
   }
 
   return (

--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -87,7 +87,6 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
 }
 
 async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
-  console.log('in custom')
   // Skip these checks because we don't have these concepts in the OVM.
   opts.skipBalance = true
   opts.skipNonce = true
@@ -150,9 +149,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   state._wrapped._clearOriginalStorageCache()
   const evm = new EVM(this, txContext, block)
 
-  console.log('---------- BEGIN TRANSACTION TRACE ----------')
   const results = (await evm.executeMessage(message)) as RunTxResult
-  console.log('----------  END TRANSACTION TRACE  ----------')
 
   /*
    * Parse results

--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -107,7 +107,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // Validate gas limit against base fee
   const basefee = tx.getBaseFee()
   const gasLimit = new BN(tx.gasLimit)
-  if (gasLimit.lt(basefee))  {
+  if (gasLimit.lt(basefee)) {
     throw new Error('base fee exceeds gas limit')
   }
   gasLimit.isub(basefee)

--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -87,6 +87,7 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
 }
 
 async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
+  console.log('in custom')
   // Skip these checks because we don't have these concepts in the OVM.
   opts.skipBalance = true
   opts.skipNonce = true

--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -108,7 +108,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // Validate gas limit against base fee
   const basefee = tx.getBaseFee()
   const gasLimit = new BN(tx.gasLimit)
-  if (gasLimit.lt(basefee)) {
+  if (gasLimit.lt(basefee))  {
     throw new Error('base fee exceeds gas limit')
   }
   gasLimit.isub(basefee)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ethereumjs-ovm",
-  "version": "4.2.0",
+  "name": "@eth-optimism/ethereumjs-vm",
+  "version": "4.2.0-alpha.0",
   "description": "An Ethereum VM implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR adds a few new features/fixes to the JS-VM which came up through integrations, and also includes some logging improvements.  Includes:
- fixing `ovmCREATE` deployment failures to fail if done by EOA contracts.
- fixing revert messages to remove the revert flag.
- variable naming updates where changed in state dump and/or c-v2 interface